### PR TITLE
[0032] Bug Fix: game init failure according to the modifiers construction params

### DIFF
--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -270,4 +270,13 @@
 		"AbilityCastAnimation"	"ACT_DOTA_CAST_ABILITY_1"
 		"AbilityCooldown"	"5"
 	}
+
+	"dummy_ability"
+	{
+		"BaseClass"	"ability_lua"
+		"ScriptFile"	"abilities/dummy_ability"
+		"AbilityBehavior"	"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetType"	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetTeam"	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+	}
 }

--- a/game/scripts/vscripts/abilities/W/ability_bloody_burst.lua
+++ b/game/scripts/vscripts/abilities/W/ability_bloody_burst.lua
@@ -95,10 +95,9 @@ function ability_bloody_burst:OnSpellStart()
         delay = 0;
         caster:AttackNoEarlierThan(0);
 
-        Particle:fireParticleLocation('BLOOD_BURST.EFFECT', location, PATTACH_POINT_FOLLOW, 5, nil, {
-            key = 0,
-            value = location
-        });
+        Particle:fireParticleLocation('BLOOD_BURST.EFFECT', location, PATTACH_POINT_FOLLOW, 5, nil,
+            { key = 0, value = location }
+        );
     end
 
     local particleId = Particle:createParticle('BLOOD_BURST.BUFF1', caster);

--- a/game/scripts/vscripts/abilities/ability_test.lua
+++ b/game/scripts/vscripts/abilities/ability_test.lua
@@ -4,45 +4,10 @@ local CLIENT = 'CLIENT';
 
 ability_test = class({});
 
-LinkLuaModifier('modifier_timer_event', 'abilities/ability_test.lua',
-    LUA_MODIFIER_MOTION_NONE);
-
 function ability_test:OnSpellStart()
-    print('!!!!!!!!!');
     CustomGameEventManager:Send_ServerToAllClients('event_call_panel_test_ability', {});
 
     if isDebugEnabled(UI, SERVER) then
         debugLog(UI, SERVER, 'Server: Request open Test Ability Panel');
     end
-end
-
-function timerEvent(duration, dataObj, callback)
-    local timerTeamNumber = 0;
-    local timer = CreateModifierThinker(nil, nil, 'modifier_timer_event', { duration = duration }, Vector(0, 0, 0),
-        timerTeamNumber, false);
-
-    print('Timer Event!!!!!');
-
-    timer._data = {
-        dataObj = dataObj, callback = callback,
-    };
-end
-
-modifier_timer_event = class({});
-
-function modifier_timer_event:OnCreated(data)
-end
-
-function modifier_timer_event:OnDestroy()
-    local timer = self:GetParent();
-    local dataObj = timer._data.dataObj;
-    local callback = timer._data.callback;
-
-    callback(dataObj);
-
-    self:Destroy();
-end
-
-if _G.timerEvent == nil then
-    _G.timerEvent = timerEvent;
 end

--- a/game/scripts/vscripts/abilities/dummy_ability.lua
+++ b/game/scripts/vscripts/abilities/dummy_ability.lua
@@ -1,0 +1,41 @@
+TIMER_TEAM_NUMBER = 0;
+DEFAULT_LOC = Vector(0, 0, 0);
+
+LinkLuaModifier('modifier_timer_event', 'abilities/dummy_ability.lua',
+    LUA_MODIFIER_MOTION_NONE);
+
+dummy_ability = class({});
+
+function dummy_ability:OnSpellStart()
+end
+
+function timerEvent(duration, dataObj, callback)
+    local timer = CreateModifierThinker(DUMMY_UNIT, nil, 'modifier_timer_event', { duration = duration }, DEFAULT_LOC,
+        TIMER_TEAM_NUMBER, false);
+
+    timer._data = {
+        dataObj = dataObj, callback = callback,
+    };
+end
+
+modifier_timer_event = class({});
+
+function modifier_timer_event:OnCreated(data)
+end
+
+function modifier_timer_event:OnDestroy()
+    local timer = self:GetParent();
+    local dataObj = timer._data.dataObj;
+    local callback = timer._data.callback;
+
+    if (callback ~= nil) then
+        callback(dataObj);
+    end
+
+    timer._data = nil;
+    self:Destroy();
+end
+
+if _G.timerEvent == nil then
+    _G.timerEvent = timerEvent;
+end

--- a/game/scripts/vscripts/addon_game_mode.lua
+++ b/game/scripts/vscripts/addon_game_mode.lua
@@ -50,13 +50,15 @@ function ToAGame:InitGameMode()
 	GameRules:GetGameModeEntity():SetAbilityTuningValueFilter(Dynamic_Wrap(ToAGame, "AbilityFilter"), self);
 	-- GameRules:GetGameModeEntity():SetDamageFilter(Dynamic_Wrap(ToAGame, 'DamageFilter'), self);
 
-	CreateUnitByName("npc_creep_test_enemy", Vector(0, 800, 0), true, nil, nil, 3);
+	_G.DUMMY_UNIT = CreateUnitByName("npc_creep_test_enemy", Vector(0, 800, 0), true, nil, nil, 3);
 	CreateUnitByName("npc_creep_test_enemy", Vector(-200, 600, 0), true, nil, nil, 3);
 	CreateUnitByName("npc_creep_test_enemy", Vector(-200, 1000, 0), true, nil, nil, 3);
 	-- CreateUnitByName("npc_creep_test_enemy", Vector(200, 600, 0), true, nil, nil, 3);
 	-- CreateUnitByName("npc_creep_test_enemy", Vector(200, 1000, 0), true, nil, nil, 3);
 
 	ListenToGameEvent('npc_spawned', Dynamic_Wrap(ToAGame, 'OnNPCSpawned'), self);
+
+	Cache:_initialize();
 end
 
 -- Evaluate the state of the game

--- a/game/scripts/vscripts/cache/simple_cache.lua
+++ b/game/scripts/vscripts/cache/simple_cache.lua
@@ -19,7 +19,7 @@ function Cache:_initialize()
         Cache._cacheSysTime = 0;
     end
 
-    CreateModifierThinker(nil, ABILITY_EFFECT_DUMMY, 'modifier_simple_cache', {}, Vector(0, 0, 0), 0, false);
+    CreateModifierThinker(DUMMY_UNIT, nil, 'modifier_simple_cache', {}, Vector(0, 0, 0), 0, false);
 end
 
 function Cache:_getCurrentTime()
@@ -155,6 +155,10 @@ function Cache:get(entry, cacheId)
     return data and data.obj or nil;
 end
 
+function Cache:hasInstance(entry, cacheId)
+    return entry and cacheId and Cache._cache[entry] and Cache._cache[entry].keyMap[cacheId];
+end
+
 --- Remove cached obj from cache, return the cached object
 ---@param entry string
 ---@param cacheId string
@@ -163,8 +167,8 @@ function Cache:remove(entry, cacheId)
     if not IsServer() then
         return;
     end
-    
-    if not entry or not cacheId or not Cache._cache[entry] or not Cache._cache[entry].keyMap[cacheId] then
+
+    if not Cache:hasInstance(entry, cacheId) then
         if isDebugEnabled(CACHE, REMOVE) then
             debugLog(CACHE, REMOVE, ('Remove cache NOT EXISTED: ' .. ' cache id: ' .. tostring(cacheId)));
         end

--- a/game/scripts/vscripts/effects/particle.lua
+++ b/game/scripts/vscripts/effects/particle.lua
@@ -233,7 +233,7 @@ end
 
 function Particle:createMissileLocation(particleName, missileInfo)
     local delay = 10;
-    local dummy = CreateModifierThinker(nil, self, 'modifier_particle_helper_dummy', { duration = delay }, missileInfo.location, 0, false);
+    local dummy = CreateModifierThinker(DUMMY_UNIT, nil, 'modifier_particle_helper_dummy', { duration = delay }, missileInfo.location, 0, false);
 
     local info = {
         EffectName =  Particle:getParticlePath(particleName),
@@ -384,7 +384,7 @@ function Particle:fireParticleDelay(particleName, target, attachPoint, delay, in
         return nil;
     end
 
-    local dummy = CreateModifierThinker(nil, self, 'modifier_particle_helper_dummy', { duration = delay, particleId = particleId }, Vector(0, 0, 0), target:GetTeamNumber(), false);
+    local dummy = CreateModifierThinker(DUMMY_UNIT, nil, 'modifier_particle_helper_dummy', { duration = delay, particleId = particleId }, Vector(0, 0, 0), target:GetTeamNumber(), false);
 
     return particleId;
 end
@@ -392,7 +392,7 @@ end
 function Particle:fireParticleLocation(particleName, location, attachPoint, delay, index, ...)
     local duration = math.min(10, (delay or 0)) + 5;
 
-    local dummy = CreateModifierThinker(nil, self, 'modifier_particle_helper_dummy', { duration = duration }, location, 0, false);
+    local dummy = CreateModifierThinker(DUMMY_UNIT, nil, 'modifier_particle_helper_dummy', { duration = duration }, location, 0, false);
     local particleId = Particle:fireParticleDelay(particleName, dummy, attachPoint, delay, index, ...);
 
     return particleId;

--- a/game/scripts/vscripts/game/init.lua
+++ b/game/scripts/vscripts/game/init.lua
@@ -5,6 +5,7 @@ require('data/main');
 require('utils/main');
 
 require('cache/simple_cache');
+require('abilities/dummy_ability');
 
 require('battle/main');
 require('boosters/main');
@@ -39,7 +40,7 @@ function _initialize()
     _G.Data = Data;                     Data:_initialize();
     _G.Utility = Utility;               Utility:_initialize();
 
-    _G.Cache = Cache;                   Cache:_initialize();
+    _G.Cache = Cache;
 
     _G.Battle = Battle;                 Battle:_initialize();
     _G.Booster = Booster;               Booster:_initialize();


### PR DESCRIPTION
**Description**
* situation: inspected and figured out the bugs after Dota2 updates: the addon game is terminated when loading the scripts. 
* root cause: after the game updates, modifiers should provide a valid caster unit (instead of nil). 
* solution: create a global ``DUMMY_UNIT`` to resolve the issue.
